### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,21 @@ The following files are provided:
     - add an `alias` to start Kratos either to `~/.bashrc` or `~/.bash_aliases` to set the Kratos enironment when opening a new terminal. E.g.:
         `alias startkratosmaster="setupkratosenv ~/software/Kratos_master"`
 
-    - `compilekratos`: compiles Kratos in serial (shared memory parallel) in `Release`
-    - `compilekratosmpi`: compiles Kratos with MPI support in `Release`
-    - `compilekratosfulldebug`: compiles Kratos in serial (shared memory parallel) in `FullDebug`
-    - `compilekratosmpifulldebug`: compiles Kratos with MPI support in `FullDebug`
+    - Commands for _compiling_ Kratos:
+        - `compilekratos`: compiles Kratos in serial (shared memory parallel) in `Release`
+        - `compilekratosmpi`: compiles Kratos with MPI support in `Release`
+        - `compilekratosfulldebug`: compiles Kratos in serial (shared memory parallel) in `FullDebug`
+        - `compilekratosmpifulldebug`: compiles Kratos with MPI support in `FullDebug`
 
-    - `runkratos`: runs serial (shared memory parallel) Kratos given the input file, e.g.:
-    `runratos MainKratos.py`
-    Note that additional arguments are passed to the script and can e.g. be used with pythons `sys.argv` (e.g. `runkratos MainKratos.py arg1 argt33`)
-    - `runkratosmpi`: runs Kratos in MPI Kratos given the input file and the number of processors to use, e.g.:
-    `runkratosmpi MainKratos.py 4`
-    Note that additional arguments are passed same as explained for `runkratos`
+    - Commands for _running_ Kratos:
+        - `runkratos`: runs serial (shared memory parallel) Kratos given the input file, e.g.:
+        `runkratos MainKratos.py`
+            - Note that additional arguments are passed to the script and can e.g. be used with pythons `sys.argv` (e.g. `runkratos MainKratos.py arg1 argt33`)
+        - `runkratosmpi`: runs Kratos in MPI Kratos given the input file and the number of processors to use, e.g.:
+        `runkratosmpi MainKratos.py 4`
+            - Note that additional arguments are passed same as explained for `runkratos`
+            - Important when using OpenMPI: Since OpenMPI version 3, it is by default not possible to use more processes than the number of theads ([reference](https://github.com/FluidityProject/fluidity/issues/182)). To overcome this, use the `OMPI_MCA_rmaps_base_oversubscribe` environment variable like in the following:
+            `export OMPI_MCA_rmaps_base_oversubscribe=1 # Allow oversubscription for MPI (needed for OpenMPI >= 3.0)`
 
 Other helpful commands:
 - silence output from programs run in terminal: e.g.: `alias virtualbox='virtualbox &> /dev/null'`

--- a/bash_kratos.sh
+++ b/bash_kratos.sh
@@ -192,16 +192,17 @@ runkratos() {
         if [[ $version == "mpi" ]]; then
             printwarning "running serial Kratos with mpi compilation!"
         fi
+
+        echo "Logfile for running serial Kratos" > $1.log
+        echo "Start date: `date`" >> $1.log
+        echo >> $1.log # add newline
+
         echo "===== SERIAL EXECUTION ====="
         ompgetthreads
         echo ""
         sleep 2
 
         local start_time=`date +%s`
-
-        echo "Logfile for running serial Kratos" > $1.log
-        echo "Start date: `date`" >> $1.log
-        echo >> $1.log # add newline
 
         python3 "$@" | tee -a $1.log # passing all the arguments
 
@@ -235,6 +236,10 @@ runkratosmpi() {
                 throwerror "the second argument has to be the number of processes"
         fi
 
+        echo "Logfile for running distributed Kratos" > $1.log
+        echo "Start date: `date`" >> $1.log
+        echo >> $1.log # add newline
+
         echo "===== PARALLEL EXECUTION ====="
         echo "with $2 processes (and setting OMP_NUM_THREADS=1)"
         echo ""
@@ -249,6 +254,9 @@ runkratosmpi() {
         local end_time=`date +%s`
         printtime start_time end_time
         export OMP_NUM_THREADS=$omp_num_threads
+
+        echo >> $1.log # add newline
+        echo "End date: `date`" >> $1.log
      fi
 }
 export -f runkratosmpi

--- a/bash_kratos.sh
+++ b/bash_kratos.sh
@@ -199,10 +199,17 @@ runkratos() {
 
         local start_time=`date +%s`
 
-        python3 "$@" # passing all the arguments
+        echo "Logfile for running serial Kratos" > $1.log
+        echo "Start date: `date`" >> $1.log
+        echo >> $1.log # add newline
+
+        python3 "$@" | tee -a $1.log # passing all the arguments
 
         local end_time=`date +%s`
         printtime start_time end_time
+
+        echo >> $1.log # add newline
+        echo "End date: `date`" >> $1.log
     fi
 }
 export -f runkratos

--- a/bash_kratos.sh
+++ b/bash_kratos.sh
@@ -237,7 +237,7 @@ runkratosmpi() {
 
         local start_time=`date +%s`
 
-        mpiexec --oversubscribe -np $2 python3 $1 --using-mpi "${@:3}" # passing all the arguments
+        mpiexec -np $2 python3 $1 --using-mpi "${@:3}" # passing all the arguments
 
         local end_time=`date +%s`
         printtime start_time end_time


### PR DESCRIPTION
Content of this PR:
- Now it automatically writes the logs to a logfile. E.g. if using `runkratos MainKratos.py` it will (additionally to the terminal output) write the output also to `MainKratos.py.log`.
- I removed the `oversubscribe` option from MPI executions, as it conflicts with MPI implementations other than OpenMPI. Now it is required to use `export OMPI_MCA_rmaps_base_oversubscribe=1` which gives the same behavior. For more info see the readme

FYI @mpentek @mtnzguillermo @ashishdarekar